### PR TITLE
Only run git submodule task if need to

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -170,7 +170,12 @@
 
   <target name="git-submodule:config"
           description="Configures Git submodules for the project.">
-    <exec command="git submodule update --init --recursive" passthru="true" checkreturn="true" />
+    <if>
+      <available file=".gitmodules" type="file" />
+      <then>
+        <exec command="git submodule update --init --recursive" passthru="true" checkreturn="true" />
+      </then>
+    </if>
   </target>
 
   <!-- ## Grunt targets -->


### PR DESCRIPTION
On very rare occasions build:ci might be run without a git context
This simply checks if a `.gitmodules` file exists before it attempts to run `git submodule update` allowing build:ci to still run, even if not in a git context